### PR TITLE
fix: metrics runtime parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Flags:
       --exporter.addr="0.0.0:9093"                         The address the http server is running at
       --exporter.interval=300                              Delay in seconds between promcheck runs
       --metrics.profile                                    Enable pprof profiling
-      --metrics.runtime                                    Enable bot runtime metrics
+      --metrics.runtime                                    Enable runtime metrics
       --metrics.prefix=""                                  Set metrics prefix path
       --log.json                                           Tell promcheck to log json and not key value pairs
       --log.level="info"                                   The log level to use for filtering logs

--- a/cmd/promcheck/main.go
+++ b/cmd/promcheck/main.go
@@ -49,7 +49,7 @@ type config struct {
 	ExporterHttpAddr             string `name:"exporter.addr" default:"0.0.0:9093" help:"The address the http server is running at"`
 	ExporterInterval             int    `name:"exporter.interval" default:"300" help:"Delay in seconds between promcheck runs"`
 	ExporterEnableProfiling      bool   `name:"metrics.profile" default:"true" help:"Enable pprof profiling"`
-	ExporterEnableRuntimeMetrics bool   `name:"metrics.runtime" default:"true" help:"Enable bot runtime metrics"`
+	ExporterEnableRuntimeMetrics bool   `name:"metrics.runtime" default:"true" help:"Enable runtime metrics"`
 	ExporterMetricsPrefix        string `name:"metrics.prefix" default:"" help:"Set metrics prefix path"`
 
 	// log parameters


### PR DESCRIPTION
Fix `--metrics.runtime` description 