### PR TITLE
Builder improvements

### DIFF
--- a/.errcheck_excludes.txt
+++ b/.errcheck_excludes.txt
@@ -1,0 +1,1 @@
+(github.com/go-kit/log.Logger).Log

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+    paths:
+      - '**.go'
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:
+          version: v1.44

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+run:
+  deadline: 5m
+  skip-dirs:
+    - internal/go
+
+linters:
+  enable:
+    - depguard
+    - godot
+    - gofumpt
+    - goimports
+    - revive
+    - whitespace
+
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - errcheck
+
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages-with-error-message:
+      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
+      - debug/elf: "Use github.com/parca-dev/parca/internal/go/debug/elf instead of debug/elf"
+      - github.com/stretchr/testify/assert: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
+      - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+      - github.com/pkg/errors: "Use fmt.Errorf instead"
+  errcheck:
+    exclude: ./.errcheck_excludes.txt
+  goimports:
+    local-prefixes: github.com/parca-dev/parca
+  gofumpt:
+    extra-rules: true
+  misspell:
+    locale: US

--- a/cmd/promcheck/main.go
+++ b/cmd/promcheck/main.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 )
 
 const (
@@ -30,9 +30,8 @@ var (
 )
 
 type config struct {
-
-	// PrometheusUrl represents the URL prometheus is running at. Required.
-	PrometheusUrl string `required:"true" name:"prometheus.url" default:"http://0.0.0.0:9090" help:"The Prometheus base url"`
+	// PrometheusURL represents the URL prometheus is running at. Required.
+	PrometheusURL string `required:"true" name:"prometheus.url" default:"http://0.0.0.0:9090" help:"The Prometheus base url"`
 
 	// check parameters
 	CheckIgnoredSelectorsRegexp []string `name:"check.ignore-selector" help:"Regexp of selectors to ignore"`
@@ -46,7 +45,7 @@ type config struct {
 
 	// exporter parameters
 	ExporterModeEnabled          bool   `name:"exporter.enabled" default:"false" help:"Run promcheck as a prometheus exporter"`
-	ExporterHttpAddr             string `name:"exporter.addr" default:"0.0.0.0:9093" help:"The address the http server is running at"`
+	ExporterHTTPAddr             string `name:"exporter.addr" default:"0.0.0.0:9093" help:"The address the http server is running at"`
 	ExporterInterval             int    `name:"exporter.interval" default:"300" help:"Delay in seconds between promcheck runs"`
 	ExporterEnableProfiling      bool   `name:"metrics.profile" default:"true" help:"Enable pprof profiling"`
 	ExporterEnableRuntimeMetrics bool   `name:"metrics.runtime" default:"true" help:"Enable runtime metrics"`

--- a/cmd/promcheck/server.go
+++ b/cmd/promcheck/server.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"context"
-	"github.com/cbrgm/promcheck/promcheck/metrics"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/oklog/run"
-	"github.com/pkg/errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
+
+	"github.com/cbrgm/promcheck/promcheck/metrics"
 )
 
 func (app *promcheckApp) runPromcheckExporter() error {
@@ -34,7 +36,7 @@ func (app *promcheckApp) runPromcheckExporter() error {
 		}))
 
 		s := http.Server{
-			Addr:    app.optExporterHttpAddr,
+			Addr:    app.optExporterHTTPAddr,
 			Handler: m,
 		}
 
@@ -84,7 +86,7 @@ func (app *promcheckApp) runPromcheckExporter() error {
 		})
 	}
 	{
-		sig := make(chan os.Signal)
+		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		gr.Add(func() error {
 			<-sig
@@ -96,7 +98,7 @@ func (app *promcheckApp) runPromcheckExporter() error {
 	}
 
 	if err := gr.Run(); err != nil {
-		return errors.Errorf("error running: %s", err)
+		return fmt.Errorf("error running: %w", err)
 	}
 	return nil
 }

--- a/promcheck/check.go
+++ b/promcheck/check.go
@@ -2,9 +2,10 @@ package promcheck
 
 import (
 	"fmt"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"regexp"
 	"time"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
 	"github.com/prometheus/prometheus/model/labels"
 	promql "github.com/prometheus/prometheus/promql/parser"
@@ -12,12 +13,11 @@ import (
 
 // PrometheusRulesCheckerConfig represents PrometheusRulesChecker configuration.
 type PrometheusRulesCheckerConfig struct {
-
 	// ProbeDelay represents the delay between selector probes
 	ProbeDelay time.Duration
 
-	// PrometheusUrl represents the Prometheus instance url
-	PrometheusUrl string
+	// PrometheusURL represents the Prometheus instance url
+	PrometheusURL string
 
 	// IgnoredSelectorsRegexp represents a list of ignored selector regexp
 	// This parameter can be used to exclude selectors from probes
@@ -40,7 +40,6 @@ type PrometheusRulesChecker struct {
 
 // RuleGroup models a rule group that contains a set of recording and alerting rules.
 type RuleGroup struct {
-
 	// Name represents the name of the rule group
 	Name string `json:"name"`
 
@@ -53,7 +52,6 @@ type RuleGroup struct {
 
 // Rule describes an alerting or recording rule.
 type Rule struct {
-
 	// Name represents the checked recording rule or alert name
 	Name string `json:"name"`
 
@@ -61,7 +59,7 @@ type Rule struct {
 	Expression string `json:"expr"`
 }
 
-// CheckResult represents a check result
+// CheckResult represents a check result.
 type CheckResult struct {
 	// File represents the checked file name
 	File string
@@ -82,12 +80,12 @@ type CheckResult struct {
 	NoResults []string
 }
 
-//NewPrometheusRulesChecker returns PrometheusRulesChecker
+// NewPrometheusRulesChecker returns PrometheusRulesChecker.
 func NewPrometheusRulesChecker(config PrometheusRulesCheckerConfig, client prometheusv1.API) *PrometheusRulesChecker {
 	return &PrometheusRulesChecker{
 		probe: newPrometheusProbe(
 			config.ProbeDelay,
-			config.PrometheusUrl,
+			config.PrometheusURL,
 			client,
 		),
 		ignoredSelectorsRegexp: config.IgnoredSelectorsRegexp,
@@ -163,7 +161,6 @@ func isIgnored(ignoredRegexp []string, selector string) bool {
 // probeSelectorResults probes the given PromQL expression string for selectors without a result value.
 // probeSelectorResults returns a list of successful selectors and failed selectors.
 func (prc *PrometheusRulesChecker) probeSelectorResults(promqlExpression string) ([]string, []string, error) {
-
 	selectorsWithoutResult := []string{}
 	selectorsWithResult := []string{}
 
@@ -190,6 +187,9 @@ func (prc *PrometheusRulesChecker) probeSelectorResults(promqlExpression string)
 			break
 		}
 		val, err := prc.probe.ProbeSelector(selector)
+		if err != nil {
+			return selectorsWithResult, selectorsWithoutResult, err
+		}
 		if val < 1 {
 			selectorsWithoutResult = append(selectorsWithoutResult, selector)
 		} else {
@@ -199,12 +199,12 @@ func (prc *PrometheusRulesChecker) probeSelectorResults(promqlExpression string)
 	return selectorsWithResult, selectorsWithoutResult, nil
 }
 
-// visit is a helper struct to traverse a PromQL expression's abstract syntax tree
+// visit is a helper struct to traverse a PromQL expression's abstract syntax tree.
 type visit struct {
 	vectorSelectors []string
 }
 
-// Visit implements Visitor interface
+// Visit implements Visitor interface.
 func (v *visit) Visit(node promql.Node, _ []promql.Node) (promql.Visitor, error) {
 	if node == nil {
 		return v, nil
@@ -235,7 +235,7 @@ func getVectorSelectorsFromExpression(promqlExpression string) ([]string, error)
 }
 
 // ignoreMatchers checks whether the given matchers are ignored.
-// ignoreMatchers returns true if the matchers are ignored, false otherwise
+// ignoreMatchers returns true if the matchers are ignored, false otherwise.
 func ignoreMatchers(matchers []*labels.Matcher) bool {
 	for _, m := range matchers {
 		if m.Name != "__name__" {

--- a/promcheck/check.go
+++ b/promcheck/check.go
@@ -113,7 +113,7 @@ func (prc *PrometheusRulesChecker) CheckRuleGroups(groups []RuleGroup) ([]CheckR
 // CheckRuleGroup checks a single rule group.
 // CheckRuleGroup returns a list of CheckResult.
 func (prc *PrometheusRulesChecker) CheckRuleGroup(group RuleGroup) ([]CheckResult, error) {
-	results := []CheckResult{}
+	results := make([]CheckResult, 0, len(group.Rules))
 	for _, rule := range group.Rules {
 		success, failed, err := prc.probeSelectorResults(rule.Expression)
 		if err != nil {

--- a/promcheck/metrics/metrics.go
+++ b/promcheck/metrics/metrics.go
@@ -2,17 +2,17 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 	"net/http/pprof"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const defaultMetricsPath = "/metrics"
 
 // Options for initializing metrics collection.
 type Options struct {
-
 	// Common prefix for the keys of the different
 	// collected metrics.
 	Prefix string

--- a/promcheck/metrics/prometheus.go
+++ b/promcheck/metrics/prometheus.go
@@ -1,11 +1,12 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"strings"
-	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -78,8 +79,8 @@ func (p *Prometheus) registerMetrics() {
 	p.registry.MustRegister(p.selectorsGaugeM)
 
 	if p.opts.EnableRuntimeMetrics {
-		p.registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-		p.registry.MustRegister(prometheus.NewGoCollector())
+		p.registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+		p.registry.MustRegister(collectors.NewGoCollector())
 	}
 }
 
@@ -99,11 +100,6 @@ func (p *Prometheus) getHandler() http.Handler {
 func (p *Prometheus) RegisterHandler(path string, mux *http.ServeMux) {
 	promHandler := p.getHandler()
 	mux.Handle(path, promHandler)
-}
-
-// sinceStart returns the seconds passed since the start time until now.
-func (p *Prometheus) sinceStart(start time.Time) float64 {
-	return time.Since(start).Seconds()
 }
 
 func (p *Prometheus) SetRuleGroupsTotal(value float64) {

--- a/promcheck/probe.go
+++ b/promcheck/probe.go
@@ -3,12 +3,13 @@ package promcheck
 import (
 	"context"
 	"fmt"
+	"time"
+
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"time"
 )
 
-// Prober represents probe
+// Prober represents probe.
 type Prober interface {
 	// ProbeSelector probes the given PromQL selector against a remote instance.
 	ProbeSelector(selector string) (float64, error)
@@ -17,14 +18,14 @@ type Prober interface {
 type prometheusProbe struct {
 	api           prometheusv1.API
 	delay         time.Duration
-	prometheusUrl string
+	prometheusURL string
 }
 
-func newPrometheusProbe(delay time.Duration, prometheusUrl string, client prometheusv1.API) Prober {
+func newPrometheusProbe(delay time.Duration, prometheusURL string, client prometheusv1.API) Prober {
 	return &prometheusProbe{
 		api:           client,
 		delay:         delay,
-		prometheusUrl: prometheusUrl,
+		prometheusURL: prometheusURL,
 	}
 }
 
@@ -46,7 +47,7 @@ func (p *prometheusProbe) probe(selector string) (float64, error) {
 	return metricValue, nil
 }
 
-// ProbeSelector implements Prober
+// ProbeSelector implements Prober.
 func (p *prometheusProbe) ProbeSelector(selector string) (float64, error) {
 	v, err := p.probe(selector)
 	if err != nil {

--- a/promcheck/report/builder.go
+++ b/promcheck/report/builder.go
@@ -4,31 +4,31 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cbrgm/promcheck/promcheck/metrics"
 	"io"
 	"os"
 
 	"github.com/fatih/color"
 	"gopkg.in/yaml.v3"
+
+	"github.com/cbrgm/promcheck/promcheck/metrics"
 )
 
 const (
-	// DefaultFormat dumps Report as Text
+	// DefaultFormat dumps Report as Text.
 	DefaultFormat = "graph"
 
-	// YAMLFormat dumps Report as YAML
+	// YAMLFormat dumps Report as YAML.
 	YAMLFormat = "yaml"
 
-	// JSONFormat dumps Report as JSON
+	// JSONFormat dumps Report as JSON.
 	JSONFormat = "json"
 
-	// PrometheusFormat converts Report to Prometheus metrics
+	// PrometheusFormat converts Report to Prometheus metrics.
 	PrometheusFormat = "prometheus"
 )
 
-// Builder represents the report
+// Builder represents the report.
 type Builder struct {
-
 	// Report represents the report data
 	Report Report `json:"promcheck" yaml:"promcheck"`
 
@@ -43,7 +43,7 @@ type Builder struct {
 	metrics metrics.Metrics
 }
 
-// NewBuilder returns a new Builder
+// NewBuilder returns a new Builder.
 func NewBuilder(outputFormat string, noColor bool, metrics metrics.Metrics) *Builder {
 	color.NoColor = noColor
 	if outputFormat == "" {
@@ -57,9 +57,8 @@ func NewBuilder(outputFormat string, noColor bool, metrics metrics.Metrics) *Bui
 	}
 }
 
-// Report represents report data
+// Report represents report data.
 type Report struct {
-
 	// Sections represents a list of result data
 	Sections Sections `json:"results,omitempty" yaml:"results,omitempty"`
 
@@ -85,9 +84,8 @@ type Report struct {
 // Sections represents a collection of sections.
 type Sections []Section
 
-// Section represents a report section
+// Section represents a report section.
 type Section struct {
-
 	// File represents the file name of the checked rule
 	File string `json:"file" yaml:"file"`
 
@@ -126,8 +124,8 @@ func (b *Builder) clear() {
 	b.Report = Report{}
 }
 
-// AddSection adds a new section to the report
-func (b *Builder) AddSection(file, group, name, expression string, failed []string, success []string) {
+// AddSection adds a new section to the report.
+func (b *Builder) AddSection(file, group, name, expression string, failed, success []string) {
 	b.Report.Sections = append(b.Report.Sections, Section{
 		File:       file,
 		Group:      group,
@@ -136,7 +134,7 @@ func (b *Builder) AddSection(file, group, name, expression string, failed []stri
 		NoResults:  failed,
 		Results:    success,
 	})
-	b.Report.SectionsCount += 1
+	b.Report.SectionsCount++
 	b.Report.TotalSelectorsFailed += len(failed)
 	b.Report.TotalSelectorsSuccess += len(success)
 }

--- a/promcheck/report/builder_test.go
+++ b/promcheck/report/builder_test.go
@@ -1,0 +1,106 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_DumpJSON(t *testing.T) {
+	buf := &bytes.Buffer{}
+	b := NewBuilder(WithWriter(buf))
+
+	// TODO: Empty Builder doesn't work.
+	// require.NoError(t, b.DumpJSON())
+	// require.JSONEq(t, `{}`, buf.String())
+
+	buf.Reset()
+
+	b.AddSection(
+		"/etc/prometheus/node_alerts.yaml",
+		"node-exporter",
+		"NodeFilesystemSpaceFillingUp",
+		`(node_filesystem_avail_bytes{fstype!="",job="node"} / node_filesystem_size_bytes{fstype!="",job="node"} * 100 < 40 and predict_linear(node_filesystem_avail_bytes{fstype!="",job="node"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node"} == 0)`,
+		[]string{},
+		[]string{
+			`node_filesystem_avail_bytes{fstype!="",job="node"}`,
+			`node_filesystem_size_bytes{fstype!="",job="node"}`,
+			`node_filesystem_avail_bytes{fstype!="",job="node"}`,
+			`node_filesystem_readonly{fstype!="",job="node"}`,
+		},
+	)
+	expected := `
+{
+  "promcheck": {
+    "results": [
+      {
+        "file": "/etc/prometheus/node_alerts.yaml",
+        "group": "node-exporter",
+        "name": "NodeFilesystemSpaceFillingUp",
+        "expression": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node\"} * 100 \u003c 40 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node\"}[6h], 24 * 60 * 60) \u003c 0 and node_filesystem_readonly{fstype!=\"\",job=\"node\"} == 0)",
+        "no_results": [],
+        "results": [
+          "node_filesystem_avail_bytes{fstype!=\"\",job=\"node\"}",
+          "node_filesystem_size_bytes{fstype!=\"\",job=\"node\"}",
+          "node_filesystem_avail_bytes{fstype!=\"\",job=\"node\"}",
+          "node_filesystem_readonly{fstype!=\"\",job=\"node\"}"
+        ]
+      }
+    ],
+    "rules_warnings": 1,
+    "selectors_success_total": 4
+  }
+}`
+	require.NoError(t, b.DumpJSON())
+	require.JSONEq(t, expected, buf.String())
+}
+
+func TestBuilder_DumpTree(t *testing.T) {
+	buf := &bytes.Buffer{}
+	b := NewBuilder(WithWriter(buf), WithoutColor())
+
+	expected := `
+.
+
+Groups total: 0, Rules total: 0
+Selectors total: 0, Results found: 0, No Results found 0 (No Results/Total: NaN%)
+`
+	require.NoError(t, b.DumpTree())
+	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(buf.String()))
+
+	buf.Reset() // clear the output buffer for the next test
+
+	b.AddSection(
+		"/etc/prometheus/node_alerts.yaml",
+		"node-exporter",
+		"NodeFilesystemSpaceFillingUp",
+		`(node_filesystem_avail_bytes{fstype!="",job="node"} / node_filesystem_size_bytes{fstype!="",job="node"} * 100 < 40 and predict_linear(node_filesystem_avail_bytes{fstype!="",job="node"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node"} == 0)`,
+		[]string{
+			`node_filesystem_avail_bytes{fstype!="",job="node"}`,
+		},
+		[]string{
+			`node_filesystem_size_bytes{fstype!="",job="node"}`,
+			`node_filesystem_avail_bytes{fstype!="",job="node"}`,
+			`node_filesystem_readonly{fstype!="",job="node"}`,
+		},
+	)
+
+	expected = `
+.
+└── [file] /etc/prometheus/node_alerts.yaml
+    └── [group] node-exporter
+        └── [3/4] NodeFilesystemSpaceFillingUp
+            ├── [✔] node_filesystem_size_bytes{fstype!="",job="node"}
+            ├── [✔] node_filesystem_avail_bytes{fstype!="",job="node"}
+            ├── [✔] node_filesystem_readonly{fstype!="",job="node"}
+            └── [✖] node_filesystem_avail_bytes{fstype!="",job="node"}
+
+Groups total: 0, Rules total: 0
+Selectors total: 4, Results found: 3, No Results found 1 (No Results/Total: 25.00%)
+`
+
+	require.NoError(t, b.DumpTree())
+	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(buf.String()))
+}

--- a/promcheck/report/metrics.go
+++ b/promcheck/report/metrics.go
@@ -14,7 +14,6 @@ func (b *Builder) ToPrometheusMetrics() error {
 		failed  []string
 	})
 	for _, section := range b.Report.Sections {
-
 		if nodeMap[section.File] == nil {
 			nodeMap[section.File] = make(map[string]map[string]struct {
 				success []string
@@ -30,13 +29,8 @@ func (b *Builder) ToPrometheusMetrics() error {
 
 		results := nodeMap[section.File][section.Group][section.Name]
 
-		for _, s := range section.Results {
-			results.success = append(results.success, s)
-		}
-
-		for _, s := range section.NoResults {
-			results.failed = append(results.failed, s)
-		}
+		results.success = append(results.success, section.Results...)
+		results.failed = append(results.failed, section.NoResults...)
 
 		nodeMap[section.File][section.Group][section.Name] = results
 	}

--- a/promcheck/report/tree.go
+++ b/promcheck/report/tree.go
@@ -16,7 +16,6 @@ const (
 )
 
 type (
-
 	// Tree represents tree structure.
 	Tree interface {
 		AddNode(text string) Tree

--- a/promcheck/report/tree.go
+++ b/promcheck/report/tree.go
@@ -17,7 +17,7 @@ const (
 
 type (
 
-	// Tree represents tree structure
+	// Tree represents tree structure.
 	Tree interface {
 		AddNode(text string) Tree
 		AddSubtree(tree Tree)
@@ -26,18 +26,17 @@ type (
 		Print() string
 	}
 
-	// node implements Tree
+	// node implements Tree.
 	node struct {
 		text  string
 		nodes []Tree
 	}
 
-	// treePrinter traverses the tree and prints the results
-	treePrinter struct {
-	}
+	// treePrinter traverses the tree and prints the results.
+	treePrinter struct{}
 )
 
-//newNode returns a new Tree structure
+// newNode returns a new Tree structure.
 func newNode(text string) Tree {
 	return &node{
 		text:  text,
@@ -45,39 +44,39 @@ func newNode(text string) Tree {
 	}
 }
 
-//AddNode adds a node to the node
+// AddNode adds a node to the node.
 func (t *node) AddNode(text string) Tree {
 	n := newNode(text)
 	t.nodes = append(t.nodes, n)
 	return n
 }
 
-//AddSubtree adds a tree as an node
+// AddSubtree adds a tree as an node.
 func (t *node) AddSubtree(tree Tree) {
 	t.nodes = append(t.nodes, tree)
 }
 
-//Text returns the node's value
+// Text returns the node's value.
 func (t *node) String() string {
 	return t.text
 }
 
-//Nodes returns all nodes in the current node
+// Nodes returns all nodes in the current node.
 func (t *node) Nodes() []Tree {
 	return t.nodes
 }
 
-//Print returns an a text representation of the node
+// Print returns an a text representation of the node.
 func (t *node) Print() string {
 	return newPrinter().printTree(t)
 }
 
-// newPrinter returns a pointer to treePrinter
+// newPrinter returns a pointer to treePrinter.
 func newPrinter() *treePrinter {
 	return &treePrinter{}
 }
 
-//Print prints a node to a string
+// Print prints a node to a string.
 func (p *treePrinter) printTree(t Tree) string {
 	return t.String() + newLine + p.printNodes(t.Nodes(), []bool{})
 }
@@ -129,7 +128,7 @@ func (p *treePrinter) printNodes(t []Tree, spaces []bool) string {
 	return result
 }
 
-// ToTree returns the report as a tree structure in text format
+// ToTree returns the report as a tree structure in text format.
 func (b *Builder) ToTree() (string, error) {
 	b.finalize()
 	// translate slice of Sections into a map structure
@@ -138,7 +137,6 @@ func (b *Builder) ToTree() (string, error) {
 		failed  []string
 	})
 	for _, section := range b.Report.Sections {
-
 		if nodeMap[section.File] == nil {
 			nodeMap[section.File] = make(map[string]map[string]struct {
 				success []string
@@ -154,13 +152,8 @@ func (b *Builder) ToTree() (string, error) {
 
 		results := nodeMap[section.File][section.Group][section.Name]
 
-		for _, s := range section.Results {
-			results.success = append(results.success, s)
-		}
-
-		for _, s := range section.NoResults {
-			results.failed = append(results.failed, s)
-		}
+		results.success = append(results.success, section.Results...)
+		results.failed = append(results.failed, section.NoResults...)
 
 		nodeMap[section.File][section.Group][section.Name] = results
 	}
@@ -168,19 +161,16 @@ func (b *Builder) ToTree() (string, error) {
 	// finally build the tree
 	root := newNode(".")
 	for file, groups := range nodeMap {
-
 		// tree depth 1: files
 		prefixedFile := fmt.Sprintf("%s %s", color.YellowString("%s", "[file]"), file)
 		fileNode := newNode(prefixedFile)
 
 		for group, rules := range groups {
-
 			// tree depth 2: groups
 			group := fmt.Sprintf("%s %s", color.YellowString("%s", "[group]"), group)
 			groupNode := newNode(group)
 
 			for rule, results := range rules {
-
 				// three depth 3: rules
 				prefixedRule := fmt.Sprintf(
 					"%s %s",


### PR DESCRIPTION
Depends on #14 to be merged first.

Refactoring on how to build the report.Builder was done so that a `io.Writer` can more easily passed for tests.

In some instances we pre-allocate the full amount of slice elements we know upfront.