### PR TITLE
feature: implement basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ For a full list of flags, please also use `promcheck --help`.
 Flags:
   -h, --help                                               Show context-sensitive help.
       --prometheus.url="http://0.0.0.0:9090"               The Prometheus base url
+      --prometheus.basic-auth-user=""                      Basic auth username
+      --prometheus.basic-auth-pass=""                      Basic auth password
       --check.ignore-selector=CHECK.IGNORE-SELECTOR,...    Regexp of selectors to ignore
       --check.ignore-group=CHECK.IGNORE-GROUP,...          Regexp of rule groups to ignore
       --check.delay=0.1                                    Delay in seconds between probe requests
@@ -153,7 +155,7 @@ Flags:
       --output.format="graph"                              The output format to use
       --output.no-color                                    Toggle colored output
       --exporter.enabled                                   Run promcheck as a prometheus exporter
-      --exporter.addr="0.0.0:9093"                         The address the http server is running at
+      --exporter.addr="0.0.0.0:9093"                       The address the http server is running at
       --exporter.interval=300                              Delay in seconds between promcheck runs
       --metrics.profile                                    Enable pprof profiling
       --metrics.runtime                                    Enable runtime metrics

--- a/cmd/promcheck/main.go
+++ b/cmd/promcheck/main.go
@@ -31,7 +31,9 @@ var (
 
 type config struct {
 	// PrometheusURL represents the URL prometheus is running at. Required.
-	PrometheusURL string `required:"true" name:"prometheus.url" default:"http://0.0.0.0:9090" help:"The Prometheus base url"`
+	PrometheusURL               string `required:"true" name:"prometheus.url" default:"http://0.0.0.0:9090" help:"The Prometheus base url"`
+	PrometheusBasicAuthUsername string `name:"prometheus.basic-auth-user" default:"" help:"Basic auth username"`
+	PrometheusBasicAuthPassword string `name:"prometheus.basic-auth-pass" default:"" help:"Basic auth password"`
 
 	// check parameters
 	CheckIgnoredSelectorsRegexp []string `name:"check.ignore-selector" help:"Regexp of selectors to ignore"`


### PR DESCRIPTION
This PR adds basic auth support to Promcheck

Username and password can be provided via the following cli flag:

* `--prometheus.basic-auth-user`
* `--prometheus.basic-auth-pass`

