### PR TITLE
feat: add option to check promql expressions passed as cli parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ You may also build `promcheck` from source (using Go 1.17+). In order to build `
 
 ## Basic Usage
 
-`promcheck` can be used in two different modes:
+`promcheck` can be used in three different modes:
 
-* Validate rules from existing rule files (and export results in various formats)
+* Validate rules passed to `promcheck` as parameters (`--check.query`)
+* Validate rules from existing rule files (`--check.files`)
 * Validate rules from a running Prometheus instance (and export results in various formats)
 
 `promcheck` can also be executed as a Prometheus exporter to check a set of rules on a regular basis and export results as scrapeable Prometheus metrics via http.
@@ -152,6 +153,7 @@ Flags:
       --check.ignore-group=CHECK.IGNORE-GROUP,...          Regexp of rule groups to ignore
       --check.delay=0.1                                    Delay in seconds between probe requests
       --check.file=STRING                                  The rule files to check.
+      --check.query=CHECK.QUERY,...                        Inline PromQL expression to check
       --output.format="graph"                              The output format to use
       --output.no-color                                    Toggle colored output
       --exporter.enabled                                   Run promcheck as a prometheus exporter

--- a/cmd/promcheck/main.go
+++ b/cmd/promcheck/main.go
@@ -40,6 +40,7 @@ type config struct {
 	CheckIgnoredGroupsRegexp    []string `name:"check.ignore-group" help:"Regexp of rule groups to ignore"`
 	CheckDelay                  float64  `name:"check.delay" default:"0.1" help:"Delay in seconds between probe requests"`
 	CheckFiles                  string   `name:"check.file" help:"The rule files to check."`
+	CheckExpressions            []string `name:"check.query" help:"Inline PromQL expression to check"`
 
 	// output parameters
 	OutputFormat  string `name:"output.format" enum:"graph,json,yaml,csv" default:"graph" help:"The output format to use"`

--- a/promcheck/report/builder.go
+++ b/promcheck/report/builder.go
@@ -94,9 +94,6 @@ type Report struct {
 	// Sections represents a list of result data
 	Sections Sections `json:"results,omitempty" yaml:"results,omitempty"`
 
-	// SectionsCount represents the length of Sections
-	SectionsCount int `json:"rules_warnings,omitempty" yaml:"rules_warnings,omitempty"`
-
 	// TotalRules represents the total amount of checked groups
 	TotalGroups int `json:"groups_total,omitempty" yaml:"groups_total,omitempty"`
 
@@ -144,7 +141,7 @@ func (s Report) Len() int {
 
 // HasContent checks if we actually have anything to report.
 func (b *Builder) HasContent() bool {
-	return b.Report.SectionsCount != 0
+	return b.Report.TotalRules != 0
 }
 
 // finalize is called by format functions and calculates additional report data.
@@ -169,15 +166,9 @@ func (b *Builder) AddSection(file, group, name, expression string, failed, succe
 		Results:    success,
 	})
 
-	b.Report.SectionsCount++
+	b.Report.TotalRules++
 	b.Report.TotalSelectorsFailed += len(failed)
 	b.Report.TotalSelectorsSuccess += len(success)
-}
-
-// AddTotalCheckedRules adds checked rules to the total amount.
-// Builder.TotalRules is used for report metrics.
-func (b *Builder) AddTotalCheckedRules(count int) {
-	b.Report.TotalRules += count
 }
 
 // AddTotalCheckedGroups adds checked groups to the total amount.

--- a/promcheck/report/builder_test.go
+++ b/promcheck/report/builder_test.go
@@ -49,7 +49,7 @@ func TestBuilder_DumpJSON(t *testing.T) {
         ]
       }
     ],
-    "rules_warnings": 1,
+    "rules_total": 1,
     "selectors_success_total": 4
   }
 }`
@@ -97,7 +97,7 @@ Selectors total: 0, Results found: 0, No Results found 0 (No Results/Total: NaN%
             ├── [✔] node_filesystem_readonly{fstype!="",job="node"}
             └── [✖] node_filesystem_avail_bytes{fstype!="",job="node"}
 
-Groups total: 0, Rules total: 0
+Groups total: 0, Rules total: 1
 Selectors total: 4, Results found: 3, No Results found 1 (No Results/Total: 25.00%)
 `
 


### PR DESCRIPTION
This PR adds a new cli flag

```
--check.query <expression>
```

which can be passed multiple times to check PromQL queries passed as cli parameters.