### PR TITLE
feat: add a strict mode option to exit with exit code 1 on empty expression results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ referenced selectors out of it and probes them against a remote Prometheus insta
     + [Prometheus Exporter](#prometheus-exporter)
 * [Configuration](#configuration)
     + [Usage Information](#usage-information)
+    + [CI/CD Usage](#cicd-usage)
     + [Output Formats](#output-formats)
 * [Container Usage](#container-usage)
 * [Kubernetes Deployment](#kubernetes-deployment)
@@ -182,6 +183,7 @@ Flags:
       --metrics.prefix=""                                  Set metrics prefix path
       --log.json                                           Tell promcheck to log json and not key value pairs
       --log.level="info"                                   The log level to use for filtering logs
+      --strict                                             Tell promcheck to exit with an error code on expressions without results
 ```
 
 `promcheck` uses 256 colors terminal mode. On 'nix OS system make sure the `TERM` environment variable is set.
@@ -196,6 +198,12 @@ Keep in mind that `promcheck` may also contain **false positives**, since there 
 intentionally do not return a result value.
 
 `promcheck` does a single HTTP request per vector selector to be probed against the remote Prometheus instance. With many rules to validate, execution time can take longer and lead to many HTTP requests. The interval between probes can be changed with the `--check.delay` flag, which results in fewer requests but increases the runtime of the tool.
+
+### CI/CD Usage
+
+`promcheck` has a flag `--strict`, which causes `promcheck` to terminate with error code `1` after a successful run if expressions without a result value were found.
+
+Therefore, `--strict` should be used, depending on the use case whether `promcheck` should fail the report step during a CI/CD workflow in case of expressions without a result, or whether the step should run successfully regardless of whether expressions have results or not.
 
 ### Output formats
 

--- a/cmd/promcheck/check.go
+++ b/cmd/promcheck/check.go
@@ -185,7 +185,7 @@ func (app *promcheckApp) checkRulesFromRuleFiles() error {
 		}
 	}
 	if hasExpressionsWithoutResult && app.optStrictMode {
-		app.report.Dump()
+		err := app.report.Dump()
 		if err != nil {
 			level.Error(app.logger).Log("msg", "failed to print report", "err", err)
 		}
@@ -281,7 +281,7 @@ func (app *promcheckApp) checkRulesFromPrometheusInstance() error {
 		}
 	}
 	if hasExpressionsWithoutResult && app.optStrictMode {
-		app.report.Dump()
+		err := app.report.Dump()
 		if err != nil {
 			level.Error(app.logger).Log("msg", "failed to print report", "err", err)
 		}
@@ -351,7 +351,7 @@ func (app *promcheckApp) checkRulesFromInlineQueries() error {
 		}
 	}
 	if hasExpressionsWithoutResult && app.optStrictMode {
-		app.report.Dump()
+		err := app.report.Dump()
 		if err != nil {
 			level.Error(app.logger).Log("msg", "failed to print report", "err", err)
 		}

--- a/cmd/promcheck/main.go
+++ b/cmd/promcheck/main.go
@@ -57,6 +57,9 @@ type config struct {
 	// log parameters
 	LogJSON  bool   `name:"log.json" default:"false" help:"Tell promcheck to log json and not key value pairs"`
 	LogLevel string `name:"log.level" default:"info" enum:"error,warn,info,debug" help:"The log level to use for filtering logs"`
+
+	// etc
+	StrictMode bool `name:"strict" default:"false" help:"Tell promcheck to exit with an error code on expressions without results"`
 }
 
 func main() {

--- a/promcheck/check.go
+++ b/promcheck/check.go
@@ -124,8 +124,8 @@ func (prc *PrometheusRulesChecker) CheckRuleGroup(group RuleGroup) ([]CheckResul
 			Name:       rule.Name,
 			Group:      group.Name,
 			Expression: rule.Expression,
-			Results:    failed,
-			NoResults:  success,
+			Results:    success,
+			NoResults:  failed,
 		}
 		results = append(results, result)
 	}


### PR DESCRIPTION
Related #33 

This PR adds a flag `--strict` to Promcheck to exit with exit code 1 on empty expression results.