### PR TITLE
chore(golangci): update golangci-lint to v.1.59.0

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-03-31T17:06:34.66091133Z",
-  "version": "1.2.12",
+  "generated_at": "2024-06-04T17:11:02.388443068Z",
+  "version": "1.2.15",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/go-lint-test.yml
+++ b/.github/workflows/go-lint-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: giantswarm/install-binary-action@v2.0.0
         with:
           binary: "golangci-lint"
-          version: "1.57.2"
+          version: "1.59.0"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
   # use the fixed version to not introduce new linters unexpectedly
-  golangci-lint-version: 1.57.2
+  golangci-lint-version: 1.59.0
 
 run:
   # golang-ci lint runtime timeout

--- a/promcheck/report/builder.go
+++ b/promcheck/report/builder.go
@@ -259,4 +259,3 @@ func (b *Builder) DumpPrometheusMetrics() error {
 	}
 	return nil
 }
-

--- a/promcheck/report/builder.go
+++ b/promcheck/report/builder.go
@@ -224,7 +224,7 @@ func (b *Builder) DumpYAML() error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(b.writer, "%v\n", res)
+	_, _ = fmt.Fprintf(b.writer, "%v\n", res)
 	return nil
 }
 
@@ -235,7 +235,7 @@ func (b *Builder) DumpJSON() error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(b.writer, "%v\n", res)
+	_, _ = fmt.Fprintf(b.writer, "%v\n", res)
 	return nil
 }
 
@@ -246,7 +246,7 @@ func (b *Builder) DumpTree() error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(b.writer, "%v\n", res)
+	_, _ = fmt.Fprintf(b.writer, "%v\n", res)
 	return nil
 }
 
@@ -259,3 +259,4 @@ func (b *Builder) DumpPrometheusMetrics() error {
 	}
 	return nil
 }
+


### PR DESCRIPTION
Update golangci-lint to v1.59.0, see https://github.com/golangci/golangci-lint/releases/tag/v1.59.0